### PR TITLE
dsls: stop parsing documentation blocks at empty lines

### DIFF
--- a/lib/metaruby/dsls/doc.rb
+++ b/lib/metaruby/dsls/doc.rb
@@ -50,6 +50,7 @@ module MetaRuby
             while true
                 case l = lines[line]
                 when /^\s*$/
+                    break
                 when /^\s*#/
                     block << l
                 else break


### PR DESCRIPTION
When given the following DSL-like code:

```
# All properties follow

# The timeout in seconds for reading I/O
property('timeout', 'double')
```

The current code would have included 'All properties follow' in the
documentation for the timeout property. This seems very unintuitive, and IMO we
should stop at the blank line. If one wants to separate documentation
paragraphs, he should do the standard way of

  # All properties follow
  #
  # The timeout in seconds for reading I/O
  property('timeout', 'double')
