### PR TITLE
gui: fix replacement of existing fragments in #push_plan

### DIFF
--- a/lib/metaruby/gui/html/fragment.rhtml
+++ b/lib/metaruby/gui/html/fragment.rhtml
@@ -1,0 +1,5 @@
+<% if fragment.id %><div id="<%= fragment.id %>"><% end %>
+<% if fragment.title %><h2><%= fragment.title %></h2><% end %>
+    <%= HTML.render_button_bar(fragment.buttons) %>
+    <%= fragment.html %>
+<% if fragment.id %></div><% end %>

--- a/lib/metaruby/gui/html/page.rb
+++ b/lib/metaruby/gui/html/page.rb
@@ -69,6 +69,7 @@ module MetaRuby::GUI
 
             PAGE_TEMPLATE = File.join(RESSOURCES_DIR, "page.rhtml")
             PAGE_BODY_TEMPLATE = File.join(RESSOURCES_DIR, "page_body.rhtml")
+            FRAGMENT_TEMPLATE  = File.join(RESSOURCES_DIR, "fragment.rhtml")
             LIST_TEMPLATE = File.join(RESSOURCES_DIR, "list.rhtml")
             ASSETS = %w{page.css jquery.min.js jquery.selectfilter.js}
 
@@ -137,6 +138,10 @@ module MetaRuby::GUI
 
             def html_body(ressource_dir: RESSOURCES_DIR)
                 load_template(PAGE_BODY_TEMPLATE).result(binding)
+            end
+
+            def html_fragment(fragment, ressource_dir: RESSOURCES_DIR)
+                load_template(FRAGMENT_TEMPLATE).result(binding)
             end
 
             def find_button_by_url(url)
@@ -230,7 +235,7 @@ module MetaRuby::GUI
                     if fragment
                         fragment.html = html
                         element = find_first_element("div##{fragment.id}")
-                        element.replace("<div id=\"#{id}\">#{html}</div>")
+                        element.replace(html_fragment(fragment))
                         return
                     end
                 end

--- a/lib/metaruby/gui/html/page_body.rhtml
+++ b/lib/metaruby/gui/html/page_body.rhtml
@@ -2,14 +2,7 @@
     <h1><%= title %></h1>
 <% end %>
 <% fragments.each do |fragment| %>
-    <% if fragment.id %>
-        <div id="<%= fragment.id %>">
-    <% end %>
-        <% if fragment.title %>
-            <h2><%= fragment.title %></h2>
-        <% end %>
-        <%= HTML.render_button_bar(fragment.buttons) %>
-        <%= fragment.html %>
+    <%= html_fragment(fragment, ressource_dir: ressource_dir) %>
     <% if fragment.id %>
         </div>
     <% end %>


### PR DESCRIPTION
The current code was not re-adding the title and button bar to the
replaced fragment. Move the fragment HTML generation in a separate
method and use it to get the same result at first generation and
during replacement.