### PR TITLE
html: change exception render to be compatible with dynamic updates

### DIFF
--- a/lib/metaruby/gui/html/exception_view.css
+++ b/lib/metaruby/gui/html/exception_view.css
@@ -1,6 +1,15 @@
 .message { font-size: 100%; font-weight: normal; background-color: rgb(176,206,234); text-align: left; }
 .backtrace_links { font-size: 100%; margin-left: 2em;}
-.backtrace { font-size: 100%; background-color: rgb(219,230,241); padding-left: 1em; }
-.backtrace_summary { font-size: 100%; background-color: rgb(219,230,241); padding-left: 1em; }
+.backtrace {
+    font-size: 100%;
+    background-color: rgb(219,230,241);
+    padding-left: 1em;
+    display: none;
+}
+.backtrace_summary {
+    font-size: 100%;
+    background-color: rgb(219,230,241);
+    padding-left: 1em;
+}
 .user_file { font-weight: bold; }
 

--- a/lib/metaruby/gui/html/exception_view.js
+++ b/lib/metaruby/gui/html/exception_view.js
@@ -1,0 +1,23 @@
+function toggleBacktraceVisibility(element) {
+    /** The ancient JS/CSS engine used by Qt4 does not set style.display
+     * from CSS. So, assume that the default is 'none'
+     */
+    if (element.style.display === "block") {
+        element.style.display = "none";
+    }
+    else {
+        element.style.display = "block";
+    }
+}
+
+function toggleFilteredBacktraceVisibility(element) {
+    id = element.id;
+    document.getElementById("backtrace_full_" + id).style.display = "none";
+    toggleBacktraceVisibility(document.getElementById("backtrace_filtered_" + id));
+}
+
+function toggleFullBacktraceVisibility(element) {
+    id = element.id;
+    document.getElementById("backtrace_filtered_" + id).style.display = "none";
+    toggleBacktraceVisibility(document.getElementById("backtrace_full_" + id));
+}


### PR DESCRIPTION
The current implementation (based on jQuery ... yuk) was only
installing handlers at startup. Use onclick handlers and vanilla
javascript instead.

This ensures that the full/filtered backtrace buttons work within e.g. the model
browser as used by the Syskit IDE

Learned a lot since then.