### PR TITLE
fix handling of keyword arguments in FindThroughMethodMissing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.1.6
-  - 2.2.2
-  - 2.3.3
-  - 2.4.1
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - jruby-9.1.13.0
 script:
     - bundle exec rake

--- a/lib/metaruby/dsls/find_through_method_missing.rb
+++ b/lib/metaruby/dsls/find_through_method_missing.rb
@@ -55,8 +55,10 @@ module MetaRuby
             end
 
             # Resolves the given method using {#find_through_method_missing}
-            def method_missing(m, *args)
-                find_through_method_missing(m, args) || super
+            def method_missing(m, *args, **kw)
+                find_args = args
+                find_args += [kw] unless kw.empty?
+                find_through_method_missing(m, find_args) || super
             end
         end
 
@@ -113,7 +115,9 @@ module MetaRuby
                 if m.end_with?(s)
                     name = m[0, m.size - s.size]
                     if !args.empty?
-                        raise ArgumentError, "expected zero arguments to #{m}, got #{args.size}", caller(4)
+                        raise ArgumentError,
+                              "expected zero arguments to #{m}, got #{args.size}",
+                              caller(4)
                     else
                         return object.send(find_method_name, name)
                     end


### PR DESCRIPTION
The current implementation was not forwarding keyword arguments
explicitly, which starts failing on Ruby 2.7 (and will fail in
the future)