### PR TITLE
fix(gui): fix handling of context menus

### DIFF
--- a/lib/metaruby/dsls/find_through_method_missing.rb
+++ b/lib/metaruby/dsls/find_through_method_missing.rb
@@ -111,16 +111,16 @@ module MetaRuby
 
             m = m.to_s
             suffix_match.each do |s, find_method_name|
-                if m.end_with?(s)
-                    name = m[0, m.size - s.size]
-                    if !args.empty?
-                        raise ArgumentError,
-                              "expected zero arguments to #{m}, got #{args.size}",
-                              caller(4)
-                    else
-                        return object.send(find_method_name, name)
-                    end
+                next unless m.end_with?(s)
+
+                name = m[0, m.size - s.size]
+                unless args.empty?
+                    raise ArgumentError,
+                          "expected zero arguments to #{m}, got #{args.size}",
+                          caller(4)
                 end
+
+                return object.send(find_method_name, name)
             end
             nil
         end

--- a/lib/metaruby/dsls/find_through_method_missing.rb
+++ b/lib/metaruby/dsls/find_through_method_missing.rb
@@ -76,10 +76,9 @@ module MetaRuby
         #   be called
         # @param [Symbol] m the method name
         # @param [Array] args the method arguments
-        # @param [Array<String>] suffixes the accessor suffixes that should be
-        #   resolved. The last argument can be a hash, in which case the keys
-        #   are used as suffixes and the values are the name of the find methods
-        #   that should be used.
+        # @param [{String=>Symbol}] suffix_match the accessor suffixes that
+        #   should be resolved, associated with the find method that should be
+        #   used to resolve them
         # @return [Object,nil] an object if one of the listed suffixes matches
         #   the method name, or nil if the method name does not match the
         #   requested pattern.

--- a/lib/metaruby/gui/html/collection.rb
+++ b/lib/metaruby/gui/html/collection.rb
@@ -76,16 +76,16 @@ module MetaRuby::GUI
             # @param [Array<Element>] links the links that should be rendered
             # @param [Hash] push_options additional options that should be
             #   passed to page#render_list
-            def render_links(title, links, push_options = Hash.new)
+            def render_links(title, links, push_options = {})
                 links.each do |el|
                     object_id_to_object[el.object.object_id] = el.object
                 end
 
                 links = links.map do |el|
                     a_node = el.format % ["<a href=\"#{el.url}\">#{el.text}</a>"]
-                    [a_node, el.attributes || Hash.new]
+                    [a_node, el.attributes || {}]
                 end
-                page.render_list(title, links, push_options)
+                page.render_list(title, links, **push_options)
             end
 
             def render_all_elements(all, options)
@@ -118,7 +118,7 @@ module MetaRuby::GUI
                 registered_exceptions.clear
                 options = Hash[id: "#{namespace}/currently_rendered_element"].merge(options)
                 begin
-                    manager.render(object, options)
+                    manager.render(object, **options)
                 rescue ::Exception => e
                     registered_exceptions << e
                 end

--- a/lib/metaruby/gui/html/collection.rb
+++ b/lib/metaruby/gui/html/collection.rb
@@ -126,6 +126,13 @@ module MetaRuby::GUI
                 page.page.current_frame.scrollToAnchor(options[:id])
             end
 
+            def populate_context_menu(menu, metaruby_browser, event)
+                view = manager.current_renderer
+                return unless view.respond_to?(:populate_context_menu)
+
+                view.populate_context_menu(menu, metaruby_browser, event)
+            end
+
             signals :updated
         end
     end

--- a/lib/metaruby/gui/model_browser.rb
+++ b/lib/metaruby/gui/model_browser.rb
@@ -57,6 +57,8 @@ module MetaRuby
             # A Page object tunes to create URIs for objects that are suitable
             # for {#model_selector}
             class Page < HTML::Page
+                attr_reader :model_selector
+
                 def initialize(model_selector, display_page)
                     super(display_page)
                     @model_selector = model_selector

--- a/lib/metaruby/gui/model_browser.rb
+++ b/lib/metaruby/gui/model_browser.rb
@@ -158,8 +158,8 @@ module MetaRuby
             # modification to have any effect (i.e. for the newly registered
             # models to appear on the selector)
             #
-            # @param [Model] type the base model class for the models that are
-            #   considered here
+            # @param [Model] root_model the base model class for the models that
+            #   are considered here
             # @param [Class] rendering_class a class from which a relevant
             #   rendering object can be created. The generated instances must
             #   follow the rules described in the documentation of

--- a/lib/metaruby/gui/model_browser.rb
+++ b/lib/metaruby/gui/model_browser.rb
@@ -190,7 +190,7 @@ module MetaRuby
                 splitter.set_stretch_factor(1, 2)
                 self.page = Page.new(@model_selector, display.page)
 
-                model_selector.connect(SIGNAL('model_selected(QVariant)')) do |mod|
+                model_selector.connect(SIGNAL("model_selected(QVariant)")) do |mod|
                     mod = mod.to_ruby
                     push_to_history(mod)
                     render_model(mod)
@@ -207,6 +207,7 @@ module MetaRuby
                     disconnect(@page, SIGNAL('fileOpenClicked(const QUrl&)'), self, SLOT('fileOpenClicked(const QUrl&)'))
                 end
                 manager.page = page
+
                 connect(page, SIGNAL('linkClicked(const QUrl&)'), self, SLOT('linkClicked(const QUrl&)'))
                 connect(page, SIGNAL('updated()'), self, SLOT('update_exceptions()'))
                 connect(page, SIGNAL('fileOpenClicked(const QUrl&)'), self, SLOT('fileOpenClicked(const QUrl&)'))
@@ -215,29 +216,29 @@ module MetaRuby
             end
 
             def linkClicked(url)
-                if url.scheme == "link"
-                    path = url.path
-                    path = path.split('/')[1..-1]
-                    select_by_path(*path)
-                end
-            end
-            slots 'linkClicked(const QUrl&)'
+                return unless url.scheme == "link"
 
-            signals 'fileOpenClicked(const QUrl&)'
+                path = url.path
+                path = path.split("/")[1..-1]
+                select_by_path(*path)
+            end
+            slots "linkClicked(const QUrl&)"
+
+            signals "fileOpenClicked(const QUrl&)"
 
             # Call to render the given model
             #
             # @param [Model] mod the model that should be rendered
             # @raise [ArgumentError] if there is no view available for the
             #   given model
-            def render_model(mod, options = Hash.new)
+            def render_model(mod, **options)
                 page.clear
                 @registered_exceptions.clear
                 reference_model, _ = manager.find_renderer(mod)
                 if mod
                     page.title = "#{mod.name} (#{reference_model.name})"
                     begin
-                        manager.render(mod, options)
+                        manager.render(mod, **options)
                     rescue ::Exception => e
                         @registered_exceptions << e
                     end

--- a/lib/metaruby/gui/model_selector.rb
+++ b/lib/metaruby/gui/model_selector.rb
@@ -60,7 +60,7 @@ module MetaRuby
 
             # Register a new object type
             #
-            # @param [Module] model_base a module or class whose all objects of
+            # @param [Module] root_model a module or class whose all objects of
             #   this type have as superclass
             # @param [String] name the string that should be used to represent
             #   objects of this type

--- a/lib/metaruby/gui/rendering_manager.rb
+++ b/lib/metaruby/gui/rendering_manager.rb
@@ -132,8 +132,9 @@ module MetaRuby
                 current_renderer&.disable
 
                 renderer.enable
-                renderer.render(object, **render_options.merge(push_options))
                 @current_renderer = renderer
+
+                renderer.render(object, **render_options.merge(push_options))
             end
 
             signals "updated()"

--- a/lib/metaruby/gui/rendering_manager.rb
+++ b/lib/metaruby/gui/rendering_manager.rb
@@ -63,13 +63,16 @@ module MetaRuby
             # Changes on which page this rendering manager should act
             def page=(page)
                 return if @page == page
+
                 @page = page
-                @available_renderers = available_renderers.map_value do |key, (value, render_options)|
-                    new_render = value.class.new(page)
-                    disconnect(value, SIGNAL('updated()'))
-                    connect(new_render, SIGNAL('updated()'), self, SIGNAL('updated()'))
-                    [new_render, render_options]
-                end
+                @available_renderers =
+                    available_renderers.map_value do |_key, (value, render_options)|
+                        new_render = value.class.new(page)
+                        disconnect(value, SIGNAL("updated()"))
+                        connect(new_render, SIGNAL("updated()"),
+                                self, SIGNAL("updated()"))
+                        [new_render, render_options]
+                    end
             end
 
             # @api private
@@ -83,29 +86,27 @@ module MetaRuby
             #   objects
             def find_renderer(mod)
                 available_renderers.find do |model, _|
-                    mod.kind_of?(model) || (mod.kind_of?(Module) && model.kind_of?(Module) && mod <= model)
+                    mod.kind_of?(model) || (
+                        mod.kind_of?(Module) &&
+                        model.kind_of?(Module) &&
+                        mod <= model
+                    )
                 end
             end
 
             # Disable the current renderer
             def disable
-                if current_renderer
-                    current_renderer.disable
-                end
+                current_renderer&.disable
             end
 
             # Enable the current renderer
             def enable
-                if current_renderer
-                    current_renderer.enable
-                end
+                current_renderer&.enable
             end
 
             # Clear the current renderer
             def clear
-                if current_renderer
-                    current_renderer.clear
-                end
+                current_renderer&.clear
             end
 
             # Call to render the given model
@@ -121,21 +122,21 @@ module MetaRuby
             #   given model
             def render(object, **push_options)
                 _, (renderer, render_options) = find_renderer(object)
-                if renderer
-                    if current_renderer
-                        current_renderer.clear
-                        current_renderer.disable
-                    end
-                    renderer.enable
-                    renderer.render(object, render_options.merge(push_options))
-                    @current_renderer = renderer
-                else
-                    Kernel.raise ArgumentError, "no view available for #{object} (#{object.class})"
+
+                unless renderer
+                    Kernel.raise ArgumentError,
+                                 "no view available for #{object} (#{object.class})"
                 end
+
+                current_renderer&.clear
+                current_renderer&.disable
+
+                renderer.enable
+                renderer.render(object, **render_options.merge(push_options))
+                @current_renderer = renderer
             end
 
-            signals 'updated()'
+            signals "updated()"
         end
     end
 end
-


### PR DESCRIPTION
There is support in the GUI bits to allow for a right click on a SVG. The syskit IDE is using this to allow hiding parts of a network. This support was broken.