### PR TITLE
chore: define FindThroughMethodMissing.standard() to ease usage

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,17 +10,19 @@ rescue LoadError
     false
 end
 
-Rake::TestTask.new(:test) do |t|
+Rake::TestTask.new("test:lib") do |t|
     t.libs << "lib"
     t.libs << "."
 
-    file_list = FileList["test/**/test_*.rb"]
-    file_list.exclude("test/gui/**/test_*.rb") unless has_gui
+    t.test_files = FileList["test/**/test_*.rb"]
+    t.test_files.exclude("test/gui/**/test_*.rb") unless has_gui
 end
+task "test" => "test:lib"
 
 task "rubocop" do
     raise "rubocop failed" unless system(ENV["RUBOCOP_CMD"] || "rubocop")
 end
+
 task "test" => "rubocop" if ENV["RUBOCOP"] != "0"
 
 task gem: :build

--- a/lib/metaruby/dsls/find_through_method_missing.rb
+++ b/lib/metaruby/dsls/find_through_method_missing.rb
@@ -6,7 +6,11 @@ module MetaRuby
         # used in conjunction with {DSLs.find_through_method_missing} and
         # {DSLs.has_through_method_missing?}
         #
-        # @example resolve 'event' objects using method_missing
+        # When following strict conventions on the naming of the accessors and the
+        # suffixes, use {.standard}. Otherwise, you may provide the various methods
+        # by hand
+        #
+        # @example resolve 'event' objects using the .standard definition
         #   class Task
         #      # Tests if this task has an event by this name
         #      #
@@ -23,19 +27,53 @@ module MetaRuby
         #      def find_event(name)
         #      end
         #
-        #      include MetaRuby::DSLs::FindThroughMethodMissing
+        #      # This defines that is necessary to access events using <name>_event
+        #      # accessors. It relies on the convention that the 'find' method for 'event'
+        #      # is 'find_event' and the 'has' method has_event?
+        #      MetaRuby::DSLs::FindThroughMethodMissing.standard(self, %w[event])
+        #   end
         #
-        #      # Check if the given method matches a find object
-        #      def has_through_method_missing?(m)
-        #        MetaRuby::DSLs.has_through_method_missing?(
-        #           self, m, '_event' => :has_event?) || super
+        # @example resolve 'event', the explicit way
+        #   class Task
+        #      # Tests if this task has an event by this name
+        #      #
+        #      # @param [String] name
+        #      # @return [Boolean]
+        #      def has_event?(name)
         #      end
         #
-        #      # Check if the given method matches a find object
+        #      # Finds an event by name
+        #      #
+        #      # @param [String] name
+        #      # @return [Object,nil] the found event, or nil if there is no
+        #      #   event by this name
+        #      def find_event(name)
+        #      end
+        #
+        #      HAS_THROUGH_METHOD_MISSING = {
+        #          "_event" => :has_event?
+        #      }.freeze
+        #
+        #      FIND_THROUGH_METHOD_MISSING = {
+        #          "_event" => :find_event
+        #      }.freeze
+        #
         #      def find_through_method_missing(m, args)
-        #        MetaRuby::DSLs.find_through_method_missing(
-        #           self, m, args, '_event' => :find_event) || super
+        #          MetaRuby::DSLs.find_through_method_missing(
+        #              m, args, FIND_THROUGH_METHOD_MISSING
+        #          )
         #      end
+        #
+        #      def has_through_method_missing(m)
+        #          MetaRuby::DSLs.has_through_method_missing(
+        #              m, HAS_THROUGH_METHOD_MISSING
+        #          )
+        #      end
+        #
+        #      # This defines that is necessary to access events using <name>_event
+        #      # accessors. It relies on the convention that the 'find' method for 'event'
+        #      # is 'find_event' and the 'has' method has_event?
+        #      include MetaRuby::DSLs::FindThroughMethodMissing
         #   end
         #
         module FindThroughMethodMissing
@@ -57,6 +95,52 @@ module MetaRuby
                 find_args = args
                 find_args += [kw] unless kw.empty?
                 find_through_method_missing(m, find_args) || super
+            end
+
+            # All-in-one implementation when following standardized conventions
+            #
+            # If you are following the pattern `find_OBJECT` and `has_OBJECT?`, then
+            # you can use this method to do all the necessary definitions so that OBJECT
+            # can be accessed with accessors of the form NAME_suffix:
+            #
+            #     standard(self, "_suffix" => "OBJECT")
+            #
+            # In the common case where "suffix" and "OBJECT" are one and the same, the
+            # hash can be replaced by an array:
+            #
+            #     standard(self, %w[OBJECT])
+            #
+            def self.standard(context, suffix_match)
+                if suffix_match.respond_to?(:to_ary)
+                    suffix_match = suffix_match.each_with_object({}) do |s, h|
+                        h["_#{s}"] = s
+                    end
+                end
+
+                has_match = suffix_match.transform_values do |v|
+                    :"has_#{v}?"
+                end
+                context.const_set(:HAS_THROUGH_METHOD_MISSING, has_match.freeze)
+
+                find_match = suffix_match.transform_values do |v|
+                    :"find_#{v}"
+                end
+                context.const_set(:FIND_THROUGH_METHOD_MISSING, find_match.freeze)
+
+                context.class_eval <<~SCRIPT, __FILE__, __LINE__ + 1
+                    def find_through_method_missing(m, args)
+                        MetaRuby::DSLs.find_through_method_missing(
+                            self, m, args, FIND_THROUGH_METHOD_MISSING
+                        ) || super
+                    end
+
+                    def has_through_method_missing?(m)
+                        MetaRuby::DSLs.has_through_method_missing?(
+                            self, m, HAS_THROUGH_METHOD_MISSING
+                        ) || super
+                    end
+                SCRIPT
+                context.include self
             end
         end
 


### PR DESCRIPTION
It assumes some reasonable convention on the suffix and `has_`/`find_` names to define the necessary methods for the overall mechanism to work, using the best practices performance-wise (namely, define constants instead of embedding the spec hashes in the methods).